### PR TITLE
Improve docker image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,6 +1,9 @@
+/build/*.a
+/build/*.o
 /demo
 /emscripten
 /src/*.jpg
 /src/*.png
 /tools
 /.idea
+/.github

--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -9,11 +9,18 @@ jobs:
   update:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - name: Publish to Registry
-        uses: elgohr/Publish-Docker-Github-Action@v5
+      - uses: actions/checkout@master
+      - name: Publish to Registry with version-tag
+        uses: elgohr/Publish-Docker-Github-Action@master
         with:
           name: webarkit/nft-marker-creator-app
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
-          tag_semver: true
+          tag_names: true
+      - name: Publish to Registry with latest-tag
+        uses: elgohr/Publish-Docker-Github-Action@master
+        with:
+          name: webarkit/nft-marker-creator-app
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+          tags: "latest"

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,7 @@ RUN apt-get update \
         git \
         curl \
         ca-certificates \
+        dos2unix \
     && mkdir /app/ \
     && mkdir /config/ \
     && mkdir /scripts/ \
@@ -35,6 +36,8 @@ RUN npm install --prefix /Nft-Marker-Creator-App
 ENV PATH  /Nft-Marker-Creator-App/src:$PATH
 
 COPY docker/scripts /scripts/
+
+RUN dos2unix /scripts/docker/entrypoint.sh
 
 #RUN chmod +x /scripts/docker/entrypoint.sh
 ENTRYPOINT ["/scripts/docker/entrypoint.sh"]


### PR DESCRIPTION
This pull request includes updates to the `.dockerignore` file, improvements to the GitHub Actions workflow for Docker builds, and modifications to the `Dockerfile` to include a new utility and convert script line endings.

Updates to `.dockerignore`:

* Added new patterns to ignore build artifacts and GitHub-related files. [`.dockerignoreR1-R9`](diffhunk://#diff-2f754321d62f08ba8392b9b168b83e24ea2852bb5d815d63e767f6c3d23c6ac5R1-R9)

Improvements to GitHub Actions workflow:

* Changed the `actions/checkout` and `elgohr/Publish-Docker-Github-Action` to use the `master` branch instead of specific versions. [`.github/workflows/build-docker.ymlL12-R26`](diffhunk://#diff-1d203d2dfb96ccf94b5e0961c7954e3bde73b4539ade27ccc301613e368b944fL12-R26)
* Added a new step to publish the Docker image with the `latest` tag. [`.github/workflows/build-docker.ymlL12-R26`](diffhunk://#diff-1d203d2dfb96ccf94b5e0961c7954e3bde73b4539ade27ccc301613e368b944fL12-R26)

Modifications to `Dockerfile`:

* Added the `dos2unix` utility to the list of installed packages. [DockerfileR15](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557R15)
* Added a command to convert the line endings of the `entrypoint.sh` script to Unix format. [DockerfileR40-R41](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557R40-R41)