### PR TITLE
Log CLI version on startup

### DIFF
--- a/src/NFTMarkerCreator.js
+++ b/src/NFTMarkerCreator.js
@@ -9,6 +9,7 @@ if (!process.env.NODE_OPTIONS) {
   return;
 }
 
+const { version } = require("../package.json");
 const path = require("path");
 const fs = require("fs");
 const sharp = require("sharp");
@@ -45,6 +46,7 @@ const imageData = {
 
 Module.onRuntimeInitialized = async function () {
   try {
+    console.log(`NFT Marker Creator version: ${version}`);
     console.log("arguments...: ", process.argv);
 
     const parsedArgs = parseCliArguments(process.argv);


### PR DESCRIPTION
This pull request introduces a minor improvement to the `src/NFTMarkerCreator.js` file by logging the current version of the NFT Marker Creator tool at runtime. This helps users and developers quickly verify which version of the tool is being executed.

* Version information is imported from `package.json` and logged to the console when the module is initialized. [[1]](diffhunk://#diff-ba6d0098da3240e40501ee4a72947fb5dba7ce77cdcd91cd863ab7388af42078R12) [[2]](diffhunk://#diff-ba6d0098da3240e40501ee4a72947fb5dba7ce77cdcd91cd863ab7388af42078R49)