### PR TITLE
ci(python): Windows wheels (MSVC) + real-PyPI publishing

### DIFF
--- a/.github/workflows/python-wheels.yml
+++ b/.github/workflows/python-wheels.yml
@@ -1,13 +1,16 @@
 name: Python wheels (PyPI)
 
-# Builds manylinux wheels + sdist for the native Python package and publishes to
-# TestPyPI on a `python-v*` tag (independent of the Node/WASM release tags).
-# `workflow_dispatch` builds the wheels WITHOUT publishing, for testing.
+# Builds manylinux + Windows wheels and an sdist for the native Python package,
+# then publishes based on the tag (independent of the Node/WASM release tags):
+#   python-v0.1.0rc1 / a1 / b1 / dev1  -> TestPyPI  (staging)
+#   python-v0.1.0     (clean X.Y.Z)     -> real PyPI
+# `workflow_dispatch` builds + tests the wheels WITHOUT publishing.
 #
-# TestPyPI publishing uses Trusted Publishing (OIDC) — no API tokens. One-time
-# setup on https://test.pypi.org: add a "pending publisher" for project
-# `nft-marker-creator` -> owner `webarkit`, repo `Nft-Marker-Creator-App`,
-# workflow `python-wheels.yml`, environment `testpypi`.
+# Publishing uses Trusted Publishing (OIDC) — no API tokens. One-time setup:
+#   TestPyPI: pending publisher for project `nft-marker-creator` -> owner
+#     `webarkit`, repo `Nft-Marker-Creator-App`, workflow `python-wheels.yml`,
+#     environment `testpypi`.
+#   PyPI: same, on https://pypi.org, environment `pypi`.
 
 on:
   push:
@@ -16,9 +19,32 @@ on:
   workflow_dispatch:
 
 jobs:
-  build_wheels:
-    name: Wheels (manylinux x86_64)
+  check-release:
+    name: Classify tag
     runs-on: ubuntu-latest
+    outputs:
+      target: ${{ steps.classify.outputs.target }}
+    steps:
+      - id: classify
+        # target = pypi (final X.Y.Z) | testpypi (prerelease) | none (dispatch)
+        run: |
+          ref="${GITHUB_REF#refs/tags/}"
+          if [[ "$GITHUB_EVENT_NAME" != "push" || "$ref" != python-v* ]]; then
+            echo "target=none" >> "$GITHUB_OUTPUT"
+          elif [[ "$ref" =~ ^python-v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "target=pypi" >> "$GITHUB_OUTPUT"
+          else
+            echo "target=testpypi" >> "$GITHUB_OUTPUT"
+          fi
+          echo "tag=$ref target=$(cat "$GITHUB_OUTPUT")"
+
+  build_wheels:
+    name: Wheels (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest]
     steps:
       - uses: actions/checkout@v7
         with:
@@ -27,7 +53,7 @@ jobs:
         uses: pypa/cibuildwheel@v2.21.3
       - uses: actions/upload-artifact@v7
         with:
-          name: cibw-wheels
+          name: cibw-wheels-${{ matrix.os }}
           path: ./wheelhouse/*.whl
 
   build_sdist:
@@ -46,10 +72,9 @@ jobs:
 
   publish_testpypi:
     name: Publish to TestPyPI
-    needs: [build_wheels, build_sdist]
+    needs: [check-release, build_wheels, build_sdist]
     runs-on: ubuntu-latest
-    # Publish only on a python-v* tag; workflow_dispatch just builds/tests.
-    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/python-v')
+    if: needs.check-release.outputs.target == 'testpypi'
     environment:
       name: testpypi
       url: https://test.pypi.org/p/nft-marker-creator
@@ -65,3 +90,22 @@ jobs:
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           repository-url: https://test.pypi.org/legacy/
+
+  publish_pypi:
+    name: Publish to PyPI
+    needs: [check-release, build_wheels, build_sdist]
+    runs-on: ubuntu-latest
+    if: needs.check-release.outputs.target == 'pypi'
+    environment:
+      name: pypi
+      url: https://pypi.org/p/nft-marker-creator
+    permissions:
+      id-token: write # required for Trusted Publishing
+    steps:
+      - uses: actions/download-artifact@v7
+        with:
+          pattern: cibw-*
+          path: dist
+          merge-multiple: true
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,14 +10,65 @@ set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 
 # The vendored ARToolKit code crashes at import under clang-21's default Release
 # flags (-O3 -DNDEBUG). Set the Release flags directly (unambiguous, unlike
-# appending via target options) to -O2; keep asserts (no NDEBUG).
-set(CMAKE_C_FLAGS_RELEASE "-O2")
-set(CMAKE_CXX_FLAGS_RELEASE "-O2")
+# appending via target options) to -O2; keep asserts (no NDEBUG). GNU/clang only
+# (MSVC uses /O2 and is unaffected).
+if(NOT MSVC)
+  set(CMAKE_C_FLAGS_RELEASE "-O2")
+  set(CMAKE_CXX_FLAGS_RELEASE "-O2")
+endif()
 
 find_package(pybind11 CONFIG REQUIRED)
-find_package(JPEG REQUIRED)
-find_package(ZLIB REQUIRED)
-find_package(Threads REQUIRED)
+
+# JPEG + zlib. Linux/macOS use system libraries (manylinux/auditwheel bundle
+# them). Windows CI runners have neither, so fetch and STATICALLY link both — a
+# self-contained _core.pyd needs no delvewheel/DLL bundling.
+if(WIN32)
+  include(FetchContent)
+  # Some vendored deps still declare cmake_minimum_required < 3.5, which CMake 4
+  # rejects; this keeps them building.
+  set(CMAKE_POLICY_VERSION_MINIMUM 3.5)
+
+  # zlib integrates via add_subdirectory (FetchContent) fine.
+  set(ZLIB_BUILD_EXAMPLES OFF CACHE BOOL "" FORCE)
+  FetchContent_Declare(zlib
+    GIT_REPOSITORY https://github.com/madler/zlib.git
+    GIT_TAG v1.3.1)
+  FetchContent_MakeAvailable(zlib)
+  set(NFT_ZLIB_TARGET zlibstatic)
+
+  # libjpeg-turbo refuses add_subdirectory (its CMakeLists errors out), so build
+  # it as a standalone ExternalProject at build time and consume the installed
+  # static lib via an imported target.
+  include(ExternalProject)
+  set(_jpeg_prefix ${CMAKE_BINARY_DIR}/_deps/jpeg-install)
+  set(_jpeg_lib ${_jpeg_prefix}/lib/jpeg-static.lib)
+  set(_jpeg_inc ${_jpeg_prefix}/include)
+  ExternalProject_Add(jpeg_ext
+    GIT_REPOSITORY https://github.com/libjpeg-turbo/libjpeg-turbo.git
+    GIT_TAG 3.0.4
+    CMAKE_ARGS
+      -DCMAKE_INSTALL_PREFIX=${_jpeg_prefix}
+      -DENABLE_SHARED=OFF -DENABLE_STATIC=ON
+      -DWITH_TURBOJPEG=OFF -DWITH_SIMD=OFF  # WITH_SIMD=OFF avoids a NASM dep
+      -DCMAKE_BUILD_TYPE=Release
+      -DCMAKE_POLICY_VERSION_MINIMUM=3.5
+    BUILD_BYPRODUCTS ${_jpeg_lib})
+  file(MAKE_DIRECTORY ${_jpeg_inc})
+  add_library(nft_jpeg STATIC IMPORTED GLOBAL)
+  set_target_properties(nft_jpeg PROPERTIES
+    IMPORTED_LOCATION ${_jpeg_lib}
+    INTERFACE_INCLUDE_DIRECTORIES ${_jpeg_inc})
+  set(NFT_JPEG_TARGET nft_jpeg)
+  set(NFT_JPEG_EXTPROJ jpeg_ext)  # _core must wait for this to build
+
+  set(NFT_DEP_INCLUDES ${zlib_SOURCE_DIR} ${zlib_BINARY_DIR})
+else()
+  find_package(JPEG REQUIRED)
+  find_package(ZLIB REQUIRED)
+  find_package(Threads REQUIRED)
+  set(NFT_JPEG_TARGET JPEG::JPEG)
+  set(NFT_ZLIB_TARGET ZLIB::ZLIB)
+endif()
 
 set(REPO ${CMAKE_CURRENT_SOURCE_DIR})
 
@@ -101,31 +152,54 @@ pybind11_add_module(_core
   ${AR_SOURCES} ${AR2_SOURCES} ${KPM_SOURCES} ${ARCORE_SOURCES}
 )
 
+# On Windows, libjpeg-turbo is an ExternalProject; _core must wait for it.
+if(NFT_JPEG_EXTPROJ)
+  add_dependencies(_core ${NFT_JPEG_EXTPROJ})
+endif()
+
 target_include_directories(_core PRIVATE
   ${WAK}/include
   ${REPO}/emscripten
   ${WSRC}/KPM/FreakMatcher
+  ${NFT_DEP_INCLUDES}
 )
 # HAVE_THREADING enables the bounded worker pool in markerCreator.cpp.
-# _LARGEFILE64_SOURCE/_FILE_OFFSET_BITS: minizip ioapi.c uses fopen64/fseeko64/
-# ftello64, which glibc only declares with these (needed on manylinux).
-target_compile_definitions(_core PRIVATE HAVE_NFT HAVE_THREADING
-  _LARGEFILE64_SOURCE _FILE_OFFSET_BITS=64)
-target_compile_options(_core PRIVATE -fno-strict-aliasing -fno-strict-overflow)
-# Hide all non-pybind symbols. pybind11 sets CXX_VISIBILITY_PRESET but not
-# C_VISIBILITY_PRESET, so the vendored C symbols (AR2/jpeg/zlib/...) would stay
-# exported and could interpose over auditwheel's bundled libjpeg. Good hygiene
-# for a Python extension (only PyInit__core needs to be visible).
-set_target_properties(_core PROPERTIES
-  C_VISIBILITY_PRESET hidden
-  CXX_VISIBILITY_PRESET hidden
-  VISIBILITY_INLINES_HIDDEN ON)
-# Link with the old 2-segment layout (-z noseparate-code). binutils' default
-# separate-code layout produces 4 PT_LOAD segments that auditwheel's patchelf
-# 0.17.2 corrupts when it grows the dynamic section (longer bundled-libjpeg
-# soname + RUNPATH), leaving DT_INIT (offset 0x25c) non-executable and crashing
-# at import. The merged layout survives patchelf's rewrite.
-target_link_options(_core PRIVATE "LINKER:-z,noseparate-code")
-target_link_libraries(_core PRIVATE JPEG::JPEG ZLIB::ZLIB Threads::Threads)
+target_compile_definitions(_core PRIVATE HAVE_NFT HAVE_THREADING)
+if(WIN32)
+  # thread_sub.c uses Win32 threads/CRITICAL_SECTION instead of pthreads.
+  # NOMINMAX: <windows.h> defines min/max macros that break std::min({...}).
+  target_compile_definitions(_core PRIVATE ARUTIL_DISABLE_PTHREADS NOMINMAX)
+else()
+  # minizip ioapi.c uses fopen64/fseeko64/ftello64, which glibc only declares
+  # with these (needed on manylinux). On Windows ioapi.h maps them to _fseeki64.
+  target_compile_definitions(_core PRIVATE _LARGEFILE64_SOURCE _FILE_OFFSET_BITS=64)
+endif()
+
+if(NOT MSVC)
+  target_compile_options(_core PRIVATE -fno-strict-aliasing -fno-strict-overflow)
+  # Hide all non-pybind symbols. pybind11 sets CXX_VISIBILITY_PRESET but not
+  # C_VISIBILITY_PRESET, so the vendored C symbols (AR2/jpeg/zlib/...) would stay
+  # exported and could interpose over auditwheel's bundled libjpeg. Good hygiene
+  # for a Python extension (only PyInit__core needs to be visible). On MSVC,
+  # pybind11 uses __declspec(dllexport) so only the module entry is exported.
+  set_target_properties(_core PROPERTIES
+    C_VISIBILITY_PRESET hidden
+    CXX_VISIBILITY_PRESET hidden
+    VISIBILITY_INLINES_HIDDEN ON)
+endif()
+
+if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
+  # Link with the old 2-segment layout (-z noseparate-code). binutils' default
+  # separate-code layout produces 4 PT_LOAD segments that auditwheel's patchelf
+  # 0.17.2 corrupts when it grows the dynamic section (longer bundled-libjpeg
+  # soname + RUNPATH), leaving DT_INIT (offset 0x25c) non-executable and crashing
+  # at import. The merged layout survives patchelf's rewrite. (GNU ld only.)
+  target_link_options(_core PRIVATE "LINKER:-z,noseparate-code")
+endif()
+
+target_link_libraries(_core PRIVATE ${NFT_JPEG_TARGET} ${NFT_ZLIB_TARGET})
+if(NOT WIN32)
+  target_link_libraries(_core PRIVATE Threads::Threads)
+endif()
 
 install(TARGETS _core DESTINATION nft_marker_creator)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,8 +20,8 @@ minimum-version = "0.8"
 cmake.version = ">=3.18"
 
 [tool.cibuildwheel]
-# Linux-first: manylinux glibc wheels for CPython 3.8-3.13. macOS/Windows need a
-# leaner source set (no glibc fopen64) and are tracked as a follow-up.
+# manylinux glibc + Windows AMD64 wheels for CPython 3.8-3.13. macOS is a
+# tracked follow-up (can't be validated locally without a Mac).
 build = "cp38-* cp39-* cp310-* cp311-* cp312-* cp313-*"
 skip = "*-musllinux*"
 build-verbosity = 1
@@ -35,6 +35,12 @@ manylinux-x86_64-image = "manylinux_2_28"
 # clang is required (GCC crashes at runtime; see python/DESIGN.md); plus libjpeg/zlib.
 before-all = "dnf install -y clang libjpeg-turbo-devel zlib-devel"
 environment = { CC = "clang", CXX = "clang++" }
+
+[tool.cibuildwheel.windows]
+# Plain MSVC (no clang needed on Windows). zlib + libjpeg-turbo are fetched and
+# statically linked by CMake, so the .pyd is self-contained and needs no
+# delvewheel repair. See python/DESIGN_windows_pypi.md.
+archs = ["AMD64"]
 
 # Keep the sdist small and buildable: exclude the Node app, demo, WASM build
 # artifacts, tests, and the big vendored submodules (WebARKitLib is fetched via

--- a/python/DESIGN_windows_pypi.md
+++ b/python/DESIGN_windows_pypi.md
@@ -1,0 +1,109 @@
+# Design: Real-PyPI publishing + Windows wheels
+
+Status: approved (brainstorming) — 2026-07-03
+Branch: `kalwalt/ci/pypi-release-and-cross-platform-wheels` (from `dev`)
+
+## Understanding summary
+
+- **Goal 1 — Real PyPI**: extend `.github/workflows/python-wheels.yml` so **prerelease**
+  tags publish to **TestPyPI** and **final** tags publish to **real PyPI**, both via
+  Trusted Publishing (OIDC, no API tokens).
+- **Goal 2 — Windows wheels first** (maintainer is on Windows 11 and can dogfood;
+  macOS deferred to a tracked follow-up because it can't be tested locally).
+- Windows is a **CMake + CI** change, not a source port: the vendored code already
+  supports Win32.
+- **Non-goals**: macOS wheels, Windows-ARM64, musllinux, any change to the working
+  Linux build. First real-PyPI version: **0.1.0**.
+
+## Key source findings (why Windows is tractable)
+
+- `lib/SRC/ARUtil/thread_sub.c` has a complete Win32 threading path
+  (`_beginthread`, `CRITICAL_SECTION`, `CONDITION_VARIABLE`) enabled by defining
+  **`ARUTIL_DISABLE_PTHREADS`**. No pthread port needed.
+- `lib/SRC/ARUtil/ioapi.h` already maps `fopen64`→`fopen`, `ftello64`→`_ftelli64`,
+  `fseeko64`→`_fseeki64` on Windows/MSVC. minizip compiles as-is; the Linux
+  `_LARGEFILE64_SOURCE`/`_FILE_OFFSET_BITS` defines must be **omitted** on Windows.
+
+## Assumptions
+
+1. **Windows compiler**: try **MSVC first** (cibuildwheel default). The "clang required"
+   rule was a *Linux GCC* codegen bug; MSVC is a different compiler with good Eigen/C++17
+   support. **clang-cl is the fallback**. *(Highest risk — validate first.)*
+2. **Windows deps**: statically link zlib + libjpeg-turbo via CMake `FetchContent`.
+   Self-contained `.pyd`, **no delvewheel**, avoids the auditwheel/patchelf problem class.
+3. Windows **AMD64**, CPython **3.8–3.13** (matching Linux).
+4. Prerelease vs final detected by a `check-release` job parsing the tag.
+5. Linux build untouched; new CMake logic lives under `if(WIN32)` / `if(NOT MSVC)`.
+6. Maintainer does the one-time real-PyPI pending-publisher setup (environment `pypi`).
+
+## Final design
+
+### Part 1 — PyPI publishing (tag-driven routing, single workflow)
+
+```
+check-release (parse tag → outputs.target = testpypi | pypi | none)
+build_wheels (matrix: ubuntu-latest, windows-latest)
+build_sdist  (ubuntu-latest)
+      → publish_testpypi  (if needs.check-release.outputs.target == 'testpypi')
+      → publish_pypi      (if needs.check-release.outputs.target == 'pypi')
+```
+
+Tag rules (PEP 440):
+- `python-v0.1.0rc1` / `...a1` / `...b1` / `...dev1` → **TestPyPI**
+- `python-v0.1.0` (clean `X.Y.Z`) → **real PyPI**
+- `workflow_dispatch` → build + test only, no publish.
+
+`check-release` is a bash-regex job exposing `target`. `publish_pypi` mirrors the
+TestPyPI job but drops `repository-url` (defaults to PyPI) and uses `environment: pypi`.
+Both keep `permissions: id-token: write`.
+
+### Part 2 — Windows wheels
+
+CMake (additive, guarded):
+```cmake
+if(WIN32)
+  target_compile_definitions(_core PRIVATE ARUTIL_DISABLE_PTHREADS)
+  # omit _LARGEFILE64_SOURCE/_FILE_OFFSET_BITS; omit Threads::Threads
+  # FetchContent + static-link zlib and libjpeg-turbo
+else()
+  # existing Linux defines + Threads::Threads + system JPEG/ZLIB
+endif()
+if(NOT MSVC)
+  # -O2 Release override, -fno-strict-aliasing, -fno-strict-overflow,
+  # visibility presets, LINKER:-z,noseparate-code
+endif()
+```
+
+cibuildwheel:
+```toml
+[tool.cibuildwheel.windows]
+archs = ["AMD64"]
+```
+No repair step (static). `build`/`skip`/`test-command` already cross-platform.
+
+Workflow: `build_wheels` gets `matrix.os: [ubuntu-latest, windows-latest]`,
+`runs-on: ${{ matrix.os }}`, per-OS artifact names merged at publish.
+
+### Risk register — all resolved via local spike (VS2022 + CMake 4.1.2 + Py 3.11)
+
+1. **MSVC miscompile** — ✅ RESOLVED. Plain MSVC builds *and* runs correctly
+   (import + threaded generation + real feature detection). No clang-cl needed.
+2. **zlib/libjpeg-turbo provisioning** — ✅ zlib via `FetchContent_MakeAvailable`
+   (`zlibstatic`); libjpeg-turbo refuses `add_subdirectory`, so via
+   `ExternalProject_Add` + imported static target (`add_dependencies(_core jpeg_ext)`).
+3. **pthreads** — ✅ our pool uses portable `std::thread`; only WebARKitLib
+   `thread_sub.c` uses pthreads, handled by `ARUTIL_DISABLE_PTHREADS`.
+4. **`NOMINMAX`** (found during spike) — `<windows.h>` min/max macros broke
+   `std::min({...})`; added to Windows defs.
+
+## Decision log
+
+| Decision | Alternatives | Why |
+| --- | --- | --- |
+| Prerelease→TestPyPI, final→PyPI | publish both always; replace TestPyPI | Keeps a staging gate before every real release. |
+| Single workflow + `check-release` gate | second workflow; scattered `contains()` | One source of truth, auditable classification. |
+| Windows before macOS | mac-first; both together | Maintainer can dogfood Windows locally; no Mac to test on. |
+| Static-link libjpeg/zlib on Windows | delvewheel + dynamic DLLs | Self-contained `.pyd`; avoids the auditwheel/patchelf failure class. |
+| MSVC first, clang-cl fallback | clang-cl first; require clang | "clang required" was Linux-GCC-specific; MSVC is the simplest default. |
+| Guard via `if(WIN32)`/`if(NOT MSVC)` | separate CMakeLists | Keep the proven Linux build byte-identical. |
+```

--- a/python/DESIGN_windows_pypi.md
+++ b/python/DESIGN_windows_pypi.md
@@ -27,8 +27,8 @@ Branch: `kalwalt/ci/pypi-release-and-cross-platform-wheels` (from `dev`)
 ## Assumptions
 
 1. **Windows compiler**: try **MSVC first** (cibuildwheel default). The "clang required"
-   rule was a *Linux GCC* codegen bug; MSVC is a different compiler with good Eigen/C++17
-   support. **clang-cl is the fallback**. *(Highest risk — validate first.)*
+   rule was a _Linux GCC_ codegen bug; MSVC is a different compiler with good Eigen/C++17
+   support. **clang-cl is the fallback**. _(Highest risk — validate first.)_
 2. **Windows deps**: statically link zlib + libjpeg-turbo via CMake `FetchContent`.
    Self-contained `.pyd`, **no delvewheel**, avoids the auditwheel/patchelf problem class.
 3. Windows **AMD64**, CPython **3.8–3.13** (matching Linux).
@@ -49,6 +49,7 @@ build_sdist  (ubuntu-latest)
 ```
 
 Tag rules (PEP 440):
+
 - `python-v0.1.0rc1` / `...a1` / `...b1` / `...dev1` → **TestPyPI**
 - `python-v0.1.0` (clean `X.Y.Z`) → **real PyPI**
 - `workflow_dispatch` → build + test only, no publish.
@@ -60,6 +61,7 @@ Both keep `permissions: id-token: write`.
 ### Part 2 — Windows wheels
 
 CMake (additive, guarded):
+
 ```cmake
 if(WIN32)
   target_compile_definitions(_core PRIVATE ARUTIL_DISABLE_PTHREADS)
@@ -75,10 +77,12 @@ endif()
 ```
 
 cibuildwheel:
+
 ```toml
 [tool.cibuildwheel.windows]
 archs = ["AMD64"]
 ```
+
 No repair step (static). `build`/`skip`/`test-command` already cross-platform.
 
 Workflow: `build_wheels` gets `matrix.os: [ubuntu-latest, windows-latest]`,
@@ -86,7 +90,7 @@ Workflow: `build_wheels` gets `matrix.os: [ubuntu-latest, windows-latest]`,
 
 ### Risk register — all resolved via local spike (VS2022 + CMake 4.1.2 + Py 3.11)
 
-1. **MSVC miscompile** — ✅ RESOLVED. Plain MSVC builds *and* runs correctly
+1. **MSVC miscompile** — ✅ RESOLVED. Plain MSVC builds _and_ runs correctly
    (import + threaded generation + real feature detection). No clang-cl needed.
 2. **zlib/libjpeg-turbo provisioning** — ✅ zlib via `FetchContent_MakeAvailable`
    (`zlibstatic`); libjpeg-turbo refuses `add_subdirectory`, so via
@@ -98,12 +102,15 @@ Workflow: `build_wheels` gets `matrix.os: [ubuntu-latest, windows-latest]`,
 
 ## Decision log
 
-| Decision | Alternatives | Why |
-| --- | --- | --- |
-| Prerelease→TestPyPI, final→PyPI | publish both always; replace TestPyPI | Keeps a staging gate before every real release. |
-| Single workflow + `check-release` gate | second workflow; scattered `contains()` | One source of truth, auditable classification. |
-| Windows before macOS | mac-first; both together | Maintainer can dogfood Windows locally; no Mac to test on. |
-| Static-link libjpeg/zlib on Windows | delvewheel + dynamic DLLs | Self-contained `.pyd`; avoids the auditwheel/patchelf failure class. |
-| MSVC first, clang-cl fallback | clang-cl first; require clang | "clang required" was Linux-GCC-specific; MSVC is the simplest default. |
-| Guard via `if(WIN32)`/`if(NOT MSVC)` | separate CMakeLists | Keep the proven Linux build byte-identical. |
+| Decision                               | Alternatives                            | Why                                                                    |
+| -------------------------------------- | --------------------------------------- | ---------------------------------------------------------------------- |
+| Prerelease→TestPyPI, final→PyPI        | publish both always; replace TestPyPI   | Keeps a staging gate before every real release.                        |
+| Single workflow + `check-release` gate | second workflow; scattered `contains()` | One source of truth, auditable classification.                         |
+| Windows before macOS                   | mac-first; both together                | Maintainer can dogfood Windows locally; no Mac to test on.             |
+| Static-link libjpeg/zlib on Windows    | delvewheel + dynamic DLLs               | Self-contained `.pyd`; avoids the auditwheel/patchelf failure class.   |
+| MSVC first, clang-cl fallback          | clang-cl first; require clang           | "clang required" was Linux-GCC-specific; MSVC is the simplest default. |
+| Guard via `if(WIN32)`/`if(NOT MSVC)`   | separate CMakeLists                     | Keep the proven Linux build byte-identical.                            |
+
+```
+
 ```


### PR DESCRIPTION
## What

Two follow-ups to the native Python package now that TestPyPI publishing works:

1. **Windows wheels** — cibuildwheel now builds `cp38`–`cp313` **win_amd64** wheels with plain **MSVC** (no clang needed on Windows).
2. **Real-PyPI publishing** — the workflow routes **prerelease** tags to TestPyPI and **final** `X.Y.Z` tags to real PyPI.

## Why

Linux-only wheels meant Windows users (incl. the maintainer) couldn't `pip install`, and the pipeline only reached TestPyPI. This finishes the cross-platform + release story.

## How

### Windows build (`CMakeLists.txt`)
All additive, behind `if(WIN32)` / `if(NOT MSVC)` guards — **the Linux build is byte-identical**:
- `ARUTIL_DISABLE_PTHREADS` → WebARKitLib `thread_sub.c` uses Win32 threads/`CRITICAL_SECTION` (our own pool already uses portable `std::thread`).
- `NOMINMAX` → `<windows.h>` min/max macros were breaking `std::min({...})`.
- Omit the Linux-only bits on Windows: `_LARGEFILE64_SOURCE`/`_FILE_OFFSET_BITS` (`ioapi.h` maps `fopen64`→`_fseeki64` itself), `Threads::Threads`, `-O2`/`-fno-strict-*`/visibility presets, and the GNU-ld `-z noseparate-code`.
- Dependencies (no system libjpeg/zlib on CI runners): **static-linked** — zlib via `FetchContent`, libjpeg-turbo via `ExternalProject_Add` (it refuses `add_subdirectory`). Self-contained `.pyd`, so **no delvewheel** and none of the auditwheel/patchelf issues we hit on Linux.

### Publishing (`.github/workflows/python-wheels.yml`)
- `build_wheels` runs on a `[ubuntu-latest, windows-latest]` matrix.
- New `check-release` job classifies the tag → `testpypi` (prerelease: `python-v*rc/a/b/dev`) | `pypi` (final `python-vX.Y.Z`) | `none` (dispatch).
- New `publish_pypi` job (Trusted Publishing, environment `pypi`); `publish_testpypi` gated on the same output.

## Validation

- **Local (Windows 11, VS2022 + CMake 4.1.2 + Py 3.11):** build → import → 2-thread marker generation, real feature detection. ✅
- **CI dispatch** ([run 28674087388](https://github.com/webarkit/Nft-Marker-Creator-App/actions/runs/28674087388)): Windows + Linux wheel jobs green, sdist green, publish jobs correctly skipped. ✅

## Reviewer notes / follow-ups

- **One-time PyPI setup required before a real release:** add a pending publisher on pypi.org (project `nft-marker-creator`, owner `webarkit`, repo `Nft-Marker-Creator-App`, workflow `python-wheels.yml`, environment `pypi`).
- Wheel version comes from `pyproject` (`0.1.0`), not the tag; the tag only routes publishing.
- **macOS wheels** remain a separate follow-up (can't be validated without a Mac).
- Design + decision log in `python/DESIGN_windows_pypi.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)